### PR TITLE
Use NOTICE instead of PRIVMSG

### DIFF
--- a/cloogleirc.icl
+++ b/cloogleirc.icl
@@ -173,7 +173,7 @@ Start w
 			| m == "!restart" = (Nothing, w)
 			| m.[0] == '!'
 				# (msgs, w) = realProcess (split " " $ m % (1, size m)) w
-				= (Just $ map (PRIVMSG recipient) msgs, w)
+				= (Just $ map (NOTICE recipient) msgs, w)
 			= (Just [], w)
 		where
 			recipient = case (\(CSepList [t:_]) -> t.[0]) t of


### PR DESCRIPTION
Previously, the bot used to reply with `PRIVMSG`. However, this can cause infinite loops when used together with other bots. Therefore, `NOTICE` is preferred, as [bots must never reply to `NOTICE`s](https://tools.ietf.org/html/rfc1459#section-4.4.2).