### PR TITLE
Add CTCP ping

### DIFF
--- a/cloogleirc.icl
+++ b/cloogleirc.icl
@@ -174,6 +174,7 @@ Start w
 			| m.[0] == '!'
 				# (msgs, w) = realProcess (split " " $ m % (1, size m)) w
 				= (Just $ map reply msgs, w)
+			| m % (0,4) == "\001PING" = (Just [reply m], w)
 			= (Just [], w)
 		where
 			reply = case (\(CSepList [t:_]) -> t.[0]) t of


### PR DESCRIPTION
CTCP ping is the default `/ping` implementation in many clients like irssi. It gives more diagnostics than `!ping`, like the latency.