### PR TITLE
Several interface improvements

### DIFF
--- a/IRC.icl
+++ b/IRC.icl
@@ -132,7 +132,7 @@ instance toString IRCUser where
 	toString m = m.irc_nick <+ maybe "" ((<+) "!") m.irc_user
 		<+ maybe "" ((<+) "@") m.irc_host
 instance toString IRCCommand where
-	toString m = jon " " (gIRCPrint{|*|} m) +++ "\r\n"
+	toString m = jon " " (gIRCPrint{|*|} m)
 instance toString IRCReplies where toString r = printToString r
 instance toString IRCErrors where toString r = printToString r
 

--- a/IRC.icl
+++ b/IRC.icl
@@ -132,7 +132,7 @@ instance toString IRCUser where
 	toString m = m.irc_nick <+ maybe "" ((<+) "!") m.irc_user
 		<+ maybe "" ((<+) "@") m.irc_host
 instance toString IRCCommand where
-	toString m = jon " " (gIRCPrint{|*|} m)
+	toString m = jon " " (gIRCPrint{|*|} m) +++ "\r\n"
 instance toString IRCReplies where toString r = printToString r
 instance toString IRCErrors where toString r = printToString r
 

--- a/IRCBot.icl
+++ b/IRCBot.icl
@@ -27,7 +27,7 @@ bot (host, port) start end state bot w
 | rpt == TR_NoSuccess
 	= (Just $ "Could not connect to " +++ host, state, w)
 // Send startup commands
-# (merr, chan, w) = send (map toString start) (fromJust chan) w
+# (merr, chan, w) = send [toString s +++ "\r\n" \\ s <- start] (fromJust chan) w
 | isError merr = (Just $ fromError merr, state, w)
 //Start processing function
 # (mer, chan, state, w) = process chan "" state bot w
@@ -59,7 +59,7 @@ process chan acc state bot w
 			# (mircc, state, w) = bot msg state w
 			| isNothing mircc = (Ok (), chan, state, w) // Bot asks to quit
 			//Possible send the commands
-			# (merr, chan, w) = send (map toString $ fromJust mircc) chan w
+			# (merr, chan, w) = send [toString c +++ "\r\n" \\ c <- fromJust mircc] chan w
 			| isError merr = (Error $ fromError merr, chan, state, w)
 			//Recurse
 			= process chan acc state bot w

--- a/IRCBot.icl
+++ b/IRCBot.icl
@@ -27,7 +27,7 @@ bot (host, port) start end state bot w
 | rpt == TR_NoSuccess
 	= (Just $ "Could not connect to " +++ host, state, w)
 // Send startup commands
-# (merr, chan, w) = send [toString s +++ "\r\n" \\ s <- start] (fromJust chan) w
+# (merr, chan, w) = send (map toString start) (fromJust chan) w
 | isError merr = (Just $ fromError merr, state, w)
 //Start processing function
 # (mer, chan, state, w) = process chan "" state bot w
@@ -59,7 +59,7 @@ process chan acc state bot w
 			# (mircc, state, w) = bot msg state w
 			| isNothing mircc = (Ok (), chan, state, w) // Bot asks to quit
 			//Possible send the commands
-			# (merr, chan, w) = send [toString c +++ "\r\n" \\ c <- fromJust mircc] chan w
+			# (merr, chan, w) = send (map toString $ fromJust mircc) chan w
 			| isError merr = (Error $ fromError merr, chan, state, w)
 			//Recurse
 			= process chan acc state bot w

--- a/cloogleirc.icl
+++ b/cloogleirc.icl
@@ -86,6 +86,9 @@ cloogle data w
 				+++ toString (length class_funs) +++ " class functions"
 		processResult (ModuleResult (br, _))
 			= "Module in " +++ br.library +++ ": " +++ br.modul
+		processResult (SyntaxResult (br, re))
+			= "Clean syntax: " +++ re.syntax_title +++ "\n"
+				+++ concat (intersperse "; " re.syntax_code)
 
 		limitResults :: String -> String
 		limitResults s

--- a/cloogleirc.icl
+++ b/cloogleirc.icl
@@ -56,7 +56,7 @@ shorten s w
 
 cloogle :: String *World -> (String, *World)
 cloogle data w
-# (mer, w) = doHTTPRequestL
+# (mer, w) = doHTTPRequestFollowRedirects
 		{ newHTTPRequest
 		& req_path = "/api.php"
 		, req_query = "?str=" + urlEncode data
@@ -107,17 +107,18 @@ cloogle data w
 
 Start :: *World -> (Maybe String, *World)
 Start w
-# ([arg0:args], w) = getCommandLine w
+# ([cmd:args], w) = getCommandLine w
 # (io, w) = stdio w
-# io = io <<< "\n"
-# bs = parseCLI args 
-//| isError bs = (Just $ "\n" +++ fromError bs +++ "\n", snd $ fclose io w)
+# bs = parseCLI cmd args
+| isError bs
+	# io = io <<< fromError bs <<< "\n"
+	= (Nothing, snd $ fclose io w)
 # (Ok bs) = bs
 # (merr, io, w) = bot (bs.bs_server, bs.bs_port) (startup bs) shutdown io (process bs.bs_strftime) w
-= (Nothing, w)//= (merr, snd $ fclose io w)
+= (merr, snd $ fclose io w)
 	where
-		parseCLI :: [String] -> MaybeErrorString BotSettings
-		parseCLI [] = Ok
+		parseCLI :: String [String] -> MaybeErrorString BotSettings
+		parseCLI _ [] = Ok
 			{ bs_nick     = "clooglebot"
 			, bs_nickserv = Nothing
 			, bs_autojoin = []
@@ -125,7 +126,7 @@ Start w
 			, bs_server   = "irc.freenode.net"
 			, bs_strftime = "%s"
 			}
-		parseCLI [a:as]
+		parseCLI cmd [a:as]
 		| a == "-f" || a == "--strftime"
 			= arg1 "--strftime" as \a c->{c & bs_strftime=a}
 		| a == "-n" || a == "--nick"
@@ -139,7 +140,7 @@ Start w
 		| a == "-s" || a == "--server"
 			= arg1 "--server" as \a c->{c & bs_server=a}
 		| a == "-h" || a == "--help" = Error $ join "\n" $
-			[ "Usage: cloogle [OPTS]"
+			[ "Usage: " + cmd + " [OPTS]"
 			, "Options:"
 			, "\t--strftime/-f FORMAT   strftime format used in the output. default: %s\n"
 			, "\t--nick/-n NICKNAME     Use the given nickname instead of clooglebot"
@@ -151,9 +152,9 @@ Start w
 			, "\t                       has to be escaped in most shells"
 			]
 		= Error $ "Unknown option: " +++ a
-
-		arg1 name [] _ = Error $ name +++ " requires an argument"
-		arg1 name [a:as] f = parseCLI as >>= Ok o f a
+		where
+			arg1 name [] _ = Error $ name +++ " requires an argument"
+			arg1 name [a:as] f = parseCLI cmd as >>= Ok o f a
 
 		nickserv pw = PRIVMSG (CSepList ["NickServ"]) $ "IDENTIFY " +++ pw
 
@@ -182,7 +183,7 @@ Start w
 		log :: String String IRCMessage (!*File, !*World) -> (!*File, !*World)
 		log strf pref m (io, w)
 		#! (t, w) = localTime w
-		= (io <<< strfTime strf t <<< pref <<< toString m, w)
+		= (io <<< strfTime strf t <<< pref <<< toString m <<< "\n", w)
 
 		process` :: (Maybe (Either IRCUser String)) IRCCommand *World -> (Maybe [IRCCommand], *World)
 		process` (Just (Left user)) (PRIVMSG t m) w


### PR DESCRIPTION
Fixes:

- Crash when `--help` was used
- In the CLI help, the actual name of the command is used instead of `cloogle`
- No newlines in the freenode welcome message

This will conflict with other PRs, sorry about that.

It's probably a good idea to add `-nr` to the Makefile, but that would conflict with an other PR so I'll leave it out for now.