### PR TITLE
Add ABCInstructionResult and ProblemResult formats

### DIFF
--- a/cloogleirc.icl
+++ b/cloogleirc.icl
@@ -90,6 +90,11 @@ cloogle data w
 		processResult (SyntaxResult (br, re))
 			= "Clean syntax: " +++ re.syntax_title +++ "\n"
 				+++ concat (intersperse "; " re.syntax_code)
+		processResult (ABCInstructionResult (br, re))
+			= "ABC instruction: " +++ re.abc_instruction
+		processResult (ProblemResult pr)
+			= "Common problem: " +++ pr.problem_title
+				+++ "; see https://github.com/clean-cloogle/common-problems/blob/master/" +++ pr.problem_key +++ ".md"
 
 		limitResults :: String -> String
 		limitResults s


### PR DESCRIPTION
Previously, getting such results would cause a runtime error.